### PR TITLE
battery class is more adapted for custom map

### DIFF
--- a/gps/client.py
+++ b/gps/client.py
@@ -1,40 +1,34 @@
 """ Client == master == GreenerEye """
 
 from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-from battery import Battery as battery
-
-import logging
-
-logging.basicConfig()
-log = logging.getLogger()
-log.setLevel(logging.DEBUG)
+import def_config as address
 
 client = ModbusClient('localhost', port=5030)
 client.connect()
 
 
 def read_value(addr):
-    fx = addr // 100
-    address = addr % 100
+    fx = addr // address.fx_addr_separator
+    addr = addr % address.fx_addr_separator
 
     if fx == 1:
-        val = client.read_coils(address).bits
+        val = client.read_coils(addr).bits[0]
     elif fx == 2:
-        val = client.read_discrete_inputs(address).bits
+        val = client.read_discrete_inputs(addr).bits[0]
     elif fx == 3:
-        val = client.read_holding_registers(address).registers
+        val = client.read_holding_registers(addr).registers[0] / address.scaling_factor
     else:
-        val = client.read_input_registers(address).registers
+        val = client.read_input_registers(addr).registers[0] / address.scaling_factor
     return val
 
-#examples
-print(read_value(battery.active_power_out))
-print(read_value(battery.reactive_power_in))
 
-#currently do not work because values are not integers!!!
-print(read_value(battery.current_l1_in))
-print(read_value(battery.voltage_l1_l2_out))
-print(read_value(battery.frequency_out))
-
+# examples
+print(read_value(address.active_power_out))
+print(read_value(address.reactive_power_in))
+print(read_value(address.current_l1_in))
+print(read_value(address.voltage_l1_l2_out))
+print(read_value(address.frequency_out))
+print(read_value(address.system_status))
+print(read_value(address.input_connected))
 
 client.close()

--- a/gps/def_config.py
+++ b/gps/def_config.py
@@ -4,41 +4,42 @@ The addresses are in following format: first digit represents the type of regist
 (coils = 1, discrete input = 2, holding reg = 3, input reg = 4);
 remaining two digits are the actual address """
 
+fx_addr_separator = 100 # used to separate registry type and actual address
+
+float_mode = "SCALE"  # means that floats are stored as ints multiplied by scaling_factor
+scaling_factor = 100  # scaling factor for floats precision
 
 # Battery Data:
 
-battery_id = 310                # str     config
-soc = 311                       # float   dep
-active_power_in = 312           # float   in
-reactive_power_in = 313         # float   in
-current_l1_in = 314             # float   dep
-current_l2_in = 315             # float   dep
-current_l3_in = 316             # float   dep
-voltage_l1_l2_in = 317          # float   semi
-voltage_l2_l3_in = 318          # float   semi
-voltage_l3_l1_in = 319          # float   semi
-frequency_in = 320              # float   semi
-active_power_out = 321          # float   in
-reactive_power_out = 322        # float   in
-current_l1_out = 323            # float   dep
-current_l2_out = 324            # float   dep
-current_l3_out = 325            # float   dep
-voltage_l1_l2_out = 326         # float   semi
-voltage_l2_l3_out = 327         # float   semi
-voltage_l3_l1_out = 328         # float   semi
-frequency_out = 329             # float   semi
-active_power_converter = 330    # float   dep
+battery_id = 310  # str     config
+soc = 311  # float   dep
+active_power_in = 312  # float   in
+reactive_power_in = 313  # float   in
+current_l1_in = 314  # float   dep
+current_l2_in = 315  # float   dep
+current_l3_in = 316  # float   dep
+voltage_l1_l2_in = 317  # float   semi
+voltage_l2_l3_in = 318  # float   semi
+voltage_l3_l1_in = 319  # float   semi
+frequency_in = 320  # float   semi
+active_power_out = 321  # float   in
+reactive_power_out = 322  # float   in
+current_l1_out = 323  # float   dep
+current_l2_out = 324  # float   dep
+current_l3_out = 325  # float   dep
+voltage_l1_l2_out = 326  # float   semi
+voltage_l2_l3_out = 327  # float   semi
+voltage_l3_l1_out = 328  # float   semi
+frequency_out = 329  # float   semi
+active_power_converter = 330  # float   dep
 reactive_power_converter = 331  # float   dep
-
 
 # Battery State
 
 time = 332
-system_status = 333             # int    const
-system_mode = 334               # int    const
-accept_values = 110             # bool   const
-converter_started = 111         # bool   in
-input_connected = 112           # bool   in
+system_status = 333  # int    const
+system_mode = 334  # int    const
+accept_values = 110  # bool   const
+converter_started = 111  # bool   in
+input_connected = 112  # bool   in
 system_on_backup_battery = 113  # bool   in
-
-

--- a/gps/main.py
+++ b/gps/main.py
@@ -1,5 +1,5 @@
 from battery import  Battery
 
-battery = Battery(60, 60, 30, 20, 1, 1, 1)
+battery = Battery('DEFAULT', 60, 60, 30, 20, 1, 1, 1)
 battery.print_all_values()
 battery.run()


### PR DESCRIPTION
custom_config is added module (currently empty).
While instantiating a battery a parameter reg_config (i.e  default or custom registry mapping) is passed. Therefore battery class is more adapted for custom mapping in future.
In particular functions get_value and set_value are made more flexible. set_value uses helper function handle_float. Right now only part of it is implemented for "SCALE" mode. Please find more specific explanation in comments.
Also, mb it will be a good idea to make a battery_manager class which would hold all getters, setters and other helpers?