### PR TITLE
Address refactoring

### DIFF
--- a/gps/battery/battery.py
+++ b/gps/battery/battery.py
@@ -1,5 +1,4 @@
 import threading
-import json
 from pymodbus.datastore import ModbusSlaveContext, ModbusSequentialDataBlock, ModbusServerContext
 from pymodbus.server.sync import ModbusTcpServer
 from battery.util import *
@@ -128,7 +127,7 @@ class Battery:
         for field in address:
             log[field] = self.get_value(address[field])
             # print("hist_soc", self.power.soc_list[0])
-            print(json.dumps(log, indent=4))
+
 
     def write_to_graph(self):
         self.graph.mutex.lock()

--- a/gps/battery/battery.py
+++ b/gps/battery/battery.py
@@ -24,65 +24,66 @@ class Battery:
 
     def __init__(self, env):
         constants = env['battery_constants']
-        self.address = env['address']
+        self.field = env['fields']
         self.id = constants['id']
         self.server = ModbusTcpServer(self.context, address=tuple(env['server_address']))
         self.update_delay = env['update_delay']
         self.max_capacity = constants['battery_capacity']
-        self.math_engine = MathEngine(self, self.address)
-        self.float_handler = get_float_handler(env['float_store'], self.store)
-        self.set_value(self.address['system_on_backup_battery'], constants['system_on_backup_battery'])
-        self.set_value(self.address['system_status'], constants['system_status'])
-        self.set_value(self.address['system_mode'], constants['system_mode'])
-        self.set_value(self.address['accept_values'], constants['accept_values'])
+        self.math_engine = MathEngine(self, self.field)
+        self.float_handler = FloatHandler(env['float_store'], self.store)
+        self.set_value(self.field['system_on_backup_battery'], constants['system_on_backup_battery'])
+        self.set_value(self.field['system_status'], constants['system_status'])
+        self.set_value(self.field['system_mode'], constants['system_mode'])
+        self.set_value(self.field['accept_values'], constants['accept_values'])
         self.db = None
         self.graph = None
 
-
-    def set_value(self, addr, value):
+    def set_value(self, field, value):
         """
         sets the value to the given address; ALL data which is assigned to  16-bit registers (meaning fx > 2) is
         multiplied by scaling factor and converted to integers first with the method handle_float()
-        :param addr: address where first digit stands for reg type
+        :param field:
         :param value: value to set
         """
-        fx = addr[0]
-        addr = addr[1]
+        fx = field[0]
+        addr = field[1]
         if fx > 2:
-            value = self.float_handler.encode_float(value)
+            mode = field[2]
+            value = self.float_handler.encode_float(value, mode)
             self.store.setValues(fx, addr, value)
         else:
             self.store.setValues(fx, addr, [value])
 
-    def get_value(self, addr):
+    def get_value(self, field):
         """
         gets the value from given address; ALL data from  16-bit registers (meaning fx > 2) is divided by scaling factor
-        :param addr: address where first digit stands for reg type
+        :param field:
         :return: value from the given address
         """
-        fx = addr[0]
-        addr = addr[1]
+        fx = field[0]
+        addr = field[1]
         if fx <= 2:
             value = self.store.getValues(fx, addr, 1)[0]
         elif fx > 2:
-            value = self.float_handler.decode_float(fx, addr)
+            mode = field[2]
+            value = self.float_handler.decode_float(fx, addr, mode)
         return value
 
     def update(self, api, rpi, apo, rpo):
         self.update_powers(api, rpi, apo, rpo)
         self.update_relational()
-        #self.print_all_values()
+        # self.print_all_values()
         if self.db: self.write_to_db()
         if self.graph: self.write_to_graph()
 
     def update_powers(self, api, rpi, apo, rpo):
-        self.set_value(self.address['active_power_in'], api)
-        self.set_value(self.address['reactive_power_in'], rpi)
-        self.set_value(self.address['active_power_out'], apo)
-        self.set_value(self.address['reactive_power_out'], rpo)
+        self.set_value(self.field['active_power_in'], api)
+        self.set_value(self.field['reactive_power_in'], rpi)
+        self.set_value(self.field['active_power_out'], apo)
+        self.set_value(self.field['reactive_power_out'], rpo)
 
     def update_relational(self):
-        address = self.address
+        address = self.field
         self.set_value(address["active_power_converter"], self.math_engine.get_active_power_converter())
         self.set_value(address["reactive_power_converter"], self.math_engine.get_reactive_power_converter())
         self.set_value(address["voltage_l1_l2_in"], self.math_engine.get_voltage_I1_I2_in())
@@ -111,7 +112,7 @@ class Battery:
         print("SERVER: is running")
 
     def write_to_db(self):
-        address = self.address
+        address = self.field
         values = []
         for field in address:
             values.append(self.get_value(address[field]))
@@ -122,7 +123,7 @@ class Battery:
         makes a dictionary and json.dumps it to output
         this way we can also save the output :)
         """
-        address = self.address
+        address = self.field
         log = {}
         for field in address:
             log[field] = self.get_value(address[field])
@@ -132,7 +133,7 @@ class Battery:
     def write_to_graph(self):
         self.graph.mutex.lock()
         for field in self.graph.graphs:
-            value = self.get_value(self.address[field])
+            value = self.get_value(self.field[field])
             self.graph.data[field].append(value)
         self.graph.data['t'] += 1
         self.graph.mutex.unlock()

--- a/gps/battery/util.py
+++ b/gps/battery/util.py
@@ -1,23 +1,16 @@
 from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
 
 
-def get_float_handler(env, store):
-    float_mode = env["float_mode"]
-    if float_mode == "COMB":
-        fh = CombFloatHandler(env, store)
-    elif float_mode == "SCALE":
-        fh = ScaleFloatHandler(env, store)
-    return fh
-
-
 class FloatHandler:
     """
     encodes/decodes float according to the way it is stored in registry
     SCALE stands for multiplying/dividing by scaling factor method, I.E. 32bit int
     COMB stands for storing the float in two registers, I.E. 32bit float
     :param value: float which should be handled
+    :param mode: "SCALE" or "COMB"
     :return: float rounded to integer
     """
+
     def __init__(self, env, store):
         self.byte_order = env["byte_order"]
         self.word_order = env["word_order"]
@@ -25,28 +18,22 @@ class FloatHandler:
         self.battery_store = store
         self.builder = BinaryPayloadBuilder(byteorder=self.byte_order, wordorder=self.word_order)
 
-
-class ScaleFloatHandler(FloatHandler):
-    def encode_float(self, value):
-        self.builder.reset()
-        self.builder.add_32bit_int((round(value * self.scaling_factor)))
+    def encode_float(self, value, mode):
+        if mode == "SCALE":
+            self.builder.reset()
+            self.builder.add_32bit_int((round(value * self.scaling_factor)))
+        else:
+            self.builder.reset()
+            self.builder.add_32bit_float(value)
         return self.builder.to_registers()
 
-    def decode_float(self, fx, addr):
-        encoded_value = self.battery_store.getValues(fx, addr, 2)
-        decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
-                                                     wordorder=self.word_order)
+    def decode_float(self, fx, addr, mode):
+        if mode == "SCALE":
+            encoded_value = self.battery_store.getValues(fx, addr, 2)
+            decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
+                                                         wordorder=self.word_order)
+        else:
+            encoded_value = self.battery_store.getValues(fx, addr, 2)
+            decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
+                                                         wordorder=self.word_order)
         return decoder.decode_32bit_int() / self.scaling_factor
-
-
-class CombFloatHandler(FloatHandler):
-    def encode_float(self, value):
-        self.builder.reset()
-        self.builder.add_32bit_float(value)
-        return self.builder.to_registers()
-
-    def decode_float(self, fx, addr):
-        encoded_value = self.battery_store.getValues(fx, addr, 2)
-        decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
-                                                     wordorder=self.word_order)
-        return decoder.decode_32bit_float()

--- a/gps/client.py
+++ b/gps/client.py
@@ -4,113 +4,68 @@ for testing if the battery server works
 """
 
 from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-from pymodbus.payload import BinaryPayloadDecoder, Endian
+from pymodbus.payload import BinaryPayloadDecoder
 
-
-# address = json_config.get_data("custom")
 
 class GreenerEye:
     def __init__(self, env):
-        self.float_mode = env["float_store"]["float_mode"]
-        self.address = env['address']
+        self.field = env['fields']
         server_address = env['server_address']
         self.client = ModbusClient(server_address[0], server_address[1])
         self.scaling_factor = env["float_store"]['scaling_factor']
         self.byte_order = env["float_store"]["byte_order"]
         self.word_order = env["float_store"]["word_order"]
 
-    def read_value(self, addr):
-        fx = addr[0]
-        addr = addr[1]
-
+    def read_value(self, field):
+        fx = field[0]
+        addr = field[1]
         if fx == 1:
             val = self.client.read_coils(addr).bits[0]
         elif fx == 2:
             val = self.client.read_discrete_inputs(addr).bits[0]
         elif fx == 3:
+            mode = field[2]
             val = self.client.read_holding_registers(addr, 2)
         else:
+            mode = field[2]
             val = self.client.read_input_registers(addr, 2).registers
-        return val
+        d = self.from_registers(val)
+        if mode == "SCALE":
+            return d.decode_32bit_int() / self.scaling_factor
+        elif mode == "COMB":
+            return d.decode_32bit_float()
+        else:
+            return d
 
     def from_registers(self, r):
         return BinaryPayloadDecoder.fromRegisters(r.registers, byteorder=self.byte_order, wordorder=self.word_order)
 
-    def scale_float_example(self):
-        r = self.client.read_holding_registers(10, 46, unit=1)
-        d = self.from_registers(r)
-
-        # this will print address 310 to 354, IE. all float registers
-
-        for x in range(0, 22):
-            print(d.decode_32bit_int() / self.scaling_factor)
-
+    def read_float_example(self):
         # examples, reading a single value
-        r = self.read_value(self.address['active_power_in'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_int() / self.scaling_factor)
+        r = self.read_value(self.field['active_power_in'])
+        print(r)
 
-        r = self.read_value(self.address['reactive_power_in'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_int() / self.scaling_factor)
+        r = self.read_value(self.field['reactive_power_in'])
+        print(r)
 
-        r = self.read_value(self.address['current_l1_in'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_int() / self.scaling_factor)
+        r = self.read_value(self.field['current_l1_in'])
+        print(r)
 
-        r = self.read_value(self.address['voltage_l1_l2_out'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_int() / self.scaling_factor)
+        r = self.read_value(self.field['voltage_l1_l2_out'])
+        print(r)
 
-        r = self.read_value(self.address['frequency_out'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_int() / self.scaling_factor)
+        r = self.read_value(self.field['frequency_out'])
+        print(r)
 
-    def comb_float_example(self):
-        r = self.client.read_holding_registers(10, 46, unit=1)
-        d = BinaryPayloadDecoder.fromRegisters(r.registers, byteorder=self.byte_order, wordorder=self.word_order)
-
-        # this will print address 310 to 354, IE. all float registers
-        for x in range(0, 22):
-            print(d.decode_32bit_float())
-
-        # examples, reading a single value
-        r = self.read_value(self.address['active_power_in'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_float())
-
-        r = self.read_value(self.address['reactive_power_in'])
-        d = self.from_registers(r)
-
-        print(d.decode_32bit_float())
-
-        r = self.read_value(self.address['current_l1_in'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_float())
-
-        r = self.read_value(self.address['voltage_l1_l2_out'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_float())
-
-        r = self.read_value(self.address['frequency_out'])
-        d = self.from_registers(r)
-        print(d.decode_32bit_float())
-
-    # uncomment the needed in correspondence with main module
     def run(self):
         self.client.connect()
         print("CLIENT: is running")
-        if self.float_mode == "COMB":
-            self.comb_float_example()
-        elif self.float_mode == "SCALE":
-            self.scale_float_example()
-        else:
-            raise NotImplementedError("no such float mode: ", self.float_mode)
+        self.read_float_example()
         self.client.close()
 
 
 if __name__ == "__main__":
     from config.env import env
+
     eye = GreenerEye(env)
     eye.run()
-

--- a/gps/config/env.py
+++ b/gps/config/env.py
@@ -1,11 +1,6 @@
 from config.update_functions import *
+from config.var_names import *
 
-comb = "COMB"
-scale = "SCALE"
-coil = 1
-discrete = 2
-holding = 3
-input = 4
 
 env = {
     # address of modbus server

--- a/gps/config/env.py
+++ b/gps/config/env.py
@@ -1,5 +1,11 @@
-from math import sin
 from config.update_functions import *
+
+comb = "COMB"
+scale = "SCALE"
+coil = 1
+discrete = 2
+holding = 3
+input = 4
 
 env = {
     # address of modbus server
@@ -52,8 +58,6 @@ env = {
 
 
     'float_store': {
-        # COMB for 2 register float storage or SCALE for storing floats with scaling factor
-        'float_mode': 'COMB',
         # only used for SCALE, increase for more precision
         'scaling_factor': 1000,
         # Defines Endianness in modbus register,  '>' is Big Endian, '<' is Little Endian
@@ -92,33 +96,34 @@ env = {
         'reactive_power_out': lambda t: quadratic(1,2,3, t)
     },
 
-    # first index is function code, second index is address
-    'address': {
-        'soc': [3, 10],
-        'active_power_in': [3, 12],
-        'reactive_power_in': [3, 14],
-        'current_l1_in': [3, 16],
-        'current_l2_in': [3, 18],
-        'current_l3_in': [3, 20],
-        'voltage_l1_l2_in': [3, 22],
-        'voltage_l2_l3_in': [3, 24],
-        'voltage_l3_l1_in': [3, 26],
-        'frequency_in': [3, 28],
-        'active_power_out': [3, 30],
-        'reactive_power_out': [3, 32],
-        'current_l1_out': [3, 34],
-        'current_l2_out': [3, 36],
-        'current_l3_out': [3, 38],
-        'voltage_l1_l2_out': [3, 40],
-        'voltage_l2_l3_out': [3, 42],
-        'voltage_l3_l1_out': [3, 44],
-        'frequency_out': [3, 46],
-        'active_power_converter': [3, 48],
-        'reactive_power_converter': [3, 50],
-        'system_status': [3, 52],
-        'system_mode': [3, 54],
-        'accept_values': [1, 10],
-        'converter_started': [1, 11],
-        'input_connected': [1, 12],
-        'system_on_backup_battery': [1, 13]}
+    # first index is function code, second index is address, third is type of float storage
+    'fields': {
+        'soc': [holding, 10, scale],
+        'active_power_in': [holding, 12, scale],
+        'reactive_power_in': [holding, 14, scale],
+        'current_l1_in': [holding, 16, comb],
+        'current_l2_in': [holding, 18, comb],
+        'current_l3_in': [holding, 20, scale],
+        'voltage_l1_l2_in': [holding, 22, comb],
+        'voltage_l2_l3_in': [holding, 24, comb],
+        'voltage_l3_l1_in': [holding, 26, scale],
+        'frequency_in': [holding, 28, scale],
+        'active_power_out': [holding, 30, scale],
+        'reactive_power_out': [holding, 32, comb],
+        'current_l1_out': [holding, 34, comb],
+        'current_l2_out': [holding, 36, scale],
+        'current_l3_out': [holding, 38, comb],
+        'voltage_l1_l2_out': [holding, 40, scale],
+        'voltage_l2_l3_out': [holding, 42, comb],
+        'voltage_l3_l1_out': [holding, 44, scale],
+        'frequency_out': [holding, 46, comb],
+        'active_power_converter': [holding, 48, scale],
+        'reactive_power_converter': [holding, 50, scale],
+
+        'system_status': [holding, 52, scale],
+        'system_mode': [holding, 54, scale],
+        'accept_values': [coil, 10],
+        'converter_started': [coil, 11],
+        'input_connected': [coil, 12],
+        'system_on_backup_battery': [coil, 13]}
 }

--- a/gps/config/env.py
+++ b/gps/config/env.py
@@ -96,7 +96,8 @@ env = {
         'reactive_power_out': lambda t: quadratic(1,2,3, t)
     },
 
-    # first index is function code, second index is address, third is type of float storage
+    # first index is function code, second index is address, third is type of float storage (applicable for holding
+    # and input registers)
     'fields': {
         'soc': [holding, 10, scale],
         'active_power_in': [holding, 12, scale],

--- a/gps/config/var_names.py
+++ b/gps/config/var_names.py
@@ -1,0 +1,7 @@
+comb = "COMB"
+scale = "SCALE"
+
+coil = 1
+discrete = 2
+holding = 3
+input = 4

--- a/gps/main.py
+++ b/gps/main.py
@@ -1,9 +1,8 @@
 from battery import Battery
 import simulations
 from database import Database
-import threading
 
-# define which environment you want to use
+
 from config.env import env
 
 

--- a/gps/simulations/historic_simulation.py
+++ b/gps/simulations/historic_simulation.py
@@ -26,7 +26,7 @@ class HistoricSimulation(PowerSimulation):
         self.apo_list = apo[start_index:]
         self.rpo_list = rpo[start_index:]
         self.soc_list = soc[start_index:]
-        self.start_soc = battery.set_value(battery.address["soc"], soc[0])
+        self.start_soc = battery.set_value(battery.field["soc"], soc[0])
         self.max_iter = len(self.api_list)-1
         self.update()
 


### PR DESCRIPTION
Some refactoring:

change in dictionary names: 'address' is 'fields' now
Each field has one optional (only for holding and input registers) element of the way of storage ("COMB"/"SCALE"). The register type is defined not with a number but with the string which is declared in new module 'var_names' to make it less error prone for user to type.

Float Handlers:

Subclasses are redundant right now, so there is one class responsible for float handling which encodes them according to the mode of that particular field.

Other:

Client read_value is adjusted according to float_mode 


