### PR TITLE
some fields are now affected by battery constants

### DIFF
--- a/src/battery/battery.py
+++ b/src/battery/battery.py
@@ -78,7 +78,6 @@ class Battery:
         if self.graph: self.write_to_graph()
 
     def update_powers(self, api, rpi, apo, rpo):
-        address = self.field
         self.set_value(self.field['active_power_in'], self.math_engine.get_active_power_in(api))
         self.set_value(self.field['reactive_power_in'], self.math_engine.get_reactive_power_in(rpi))
         self.set_value(self.field['active_power_out'], self.math_engine.get_active_power_out(apo))
@@ -105,10 +104,10 @@ class Battery:
         self.set_value(address["soc"], self.math_engine.get_soc())
 
     def is_input_connected(self):
-        return self.field['input_connected']
+        return self.get_value(self.field['input_connected'])
 
     def is_converter_started(self):
-        return self.field['converter_started']
+        return self.get_value(self.field['converter_started'])
 
     def run_server(self, context, env):
         """
@@ -135,7 +134,6 @@ class Battery:
         log = {}
         for field in address:
             log[field] = self.get_value(address[field])
-            # print("hist_soc", self.power.soc_list[0])
 
     def write_to_graph(self):
         self.graph.mutex.lock()

--- a/src/battery/battery.py
+++ b/src/battery/battery.py
@@ -107,6 +107,9 @@ class Battery:
     def is_input_connected(self):
         return self.field['input_connected']
 
+    def is_converter_started(self):
+        return self.field['converter_started']
+
     def run_server(self, context, env):
         """
         starts the servers with filled in context

--- a/src/battery/battery.py
+++ b/src/battery/battery.py
@@ -56,7 +56,6 @@ class Battery:
         else:
             self.store.setValues(fx, addr, [value])
 
-
     def get_value(self, field):
         """
         gets the value from given address; ALL data from  16-bit registers (meaning fx > 2) is divided by scaling factor
@@ -79,7 +78,7 @@ class Battery:
         if self.graph: self.write_to_graph()
 
     def update_powers(self, api, rpi, apo, rpo):
-        address = self.field        
+        address = self.field
         self.set_value(self.field['active_power_in'], self.math_engine.get_active_power_in(api))
         self.set_value(self.field['reactive_power_in'], self.math_engine.get_reactive_power_in(rpi))
         self.set_value(self.field['active_power_out'], self.math_engine.get_active_power_out(apo))
@@ -105,12 +104,15 @@ class Battery:
         self.set_value(address["frequency_out"], self.math_engine.get_frequency_out())
         self.set_value(address["soc"], self.math_engine.get_soc())
 
+    def is_input_connected(self):
+        return self.field['input_connected']
+
     def run_server(self, context, env):
         """
         starts the servers with filled in context
         runs in separate thread
         """
-        t = threading.Thread(target=StartTcpServer, kwargs={'context':context, 'address':tuple(env)}, daemon=True)        
+        t = threading.Thread(target=StartTcpServer, kwargs={'context': context, 'address': tuple(env)}, daemon=True)
         t.start()  # start the thread
         print("SERVER: is running")
 
@@ -131,7 +133,6 @@ class Battery:
         for field in address:
             log[field] = self.get_value(address[field])
             # print("hist_soc", self.power.soc_list[0])
-
 
     def write_to_graph(self):
         self.graph.mutex.lock()

--- a/src/battery/battery.py
+++ b/src/battery/battery.py
@@ -34,6 +34,8 @@ class Battery:
         self.set_value(self.field['system_status'], constants['system_status'])
         self.set_value(self.field['system_mode'], constants['system_mode'])
         self.set_value(self.field['accept_values'], constants['accept_values'])
+        self.set_value(self.field['converter_started'], constants['converter_started'])
+        self.set_value(self.field['input_connected'], constants['input_connected'])
         self.db = None
         self.graph = None
 
@@ -77,10 +79,11 @@ class Battery:
         if self.graph: self.write_to_graph()
 
     def update_powers(self, api, rpi, apo, rpo):
-        self.set_value(self.field['active_power_in'], api)
-        self.set_value(self.field['reactive_power_in'], rpi)
-        self.set_value(self.field['active_power_out'], apo)
-        self.set_value(self.field['reactive_power_out'], rpo)
+        address = self.field        
+        self.set_value(self.field['active_power_in'], self.math_engine.get_active_power_in(api))
+        self.set_value(self.field['reactive_power_in'], self.math_engine.get_reactive_power_in(rpi))
+        self.set_value(self.field['active_power_out'], self.math_engine.get_active_power_out(apo))
+        self.set_value(self.field['reactive_power_out'], self.math_engine.get_reactive_power_out(rpo))
 
     def update_relational(self):
         address = self.field

--- a/src/battery/math_engine.py
+++ b/src/battery/math_engine.py
@@ -48,7 +48,7 @@ class MathEngine:
         """
         :return: active_power_in - active_power_out
         """
-        if not self.battery.get_value(self.address['converter_started']):
+        if not self.battery.is_converter_started():
             apc = 0
         else:
             apc = self.battery.get_value(self.address['active_power_in']) - self.battery.get_value(self.address['active_power_out'])
@@ -70,6 +70,8 @@ class MathEngine:
         :return: previous SoC + [(active_power_converter) /
                 max battery capacity * 3600.
         """
+        if not self.battery.is_converter_started():
+            return self.battery.get_value(self.address['soc'])
         prev_soc = self.battery.get_value(self.address['soc'])
         apc = self.battery.get_value(self.address['active_power_converter'])
         new_soc = prev_soc + (apc / (self.battery.max_capacity * 3600)) * 100

--- a/src/battery/math_engine.py
+++ b/src/battery/math_engine.py
@@ -24,8 +24,6 @@ class MathEngine:
         return apo
     
     def get_reactive_power_out(self, rpo):
-        #if not self.battery.is_input_connected():
-            #rpo = 0
         return rpo
 
     def get_power_factor_in(self):

--- a/src/battery/math_engine.py
+++ b/src/battery/math_engine.py
@@ -10,6 +10,28 @@ class MathEngine:
     def random_gaussian_value(self, mu, sigma):
         return np.random.normal(mu, sigma)
 
+    def get_active_power_in(self, api):
+        
+        if not self.battery.get_value(self.address['input_connected']):
+            api = 0
+        return api
+    
+    def get_reactive_power_in(self, rpi):
+        
+        if not self.battery.get_value(self.address['input_connected']):
+            rpi = 0
+        return rpi
+    
+    def get_active_power_out(self, apo):
+        
+        return apo
+    
+    def get_reactive_power_out(self, rpo):
+        
+        if not self.battery.get_value(self.address['input_connected']):
+            rpo = 0
+        return rpo
+
     def get_power_factor_in(self):
         """
         :return: active_power_in / sqrt(active_power_in^2 + reactive_power_in^2)
@@ -30,15 +52,21 @@ class MathEngine:
         """
         :return: active_power_in - active_power_out
         """
-        apc = self.battery.get_value(self.address['active_power_in']) - self.battery.get_value(self.address['active_power_out'])
+        if not self.battery.get_value(self.address['converter_started']):
+            apc = 0
+        else:
+            apc = self.battery.get_value(self.address['active_power_in']) - self.battery.get_value(self.address['active_power_out'])
         return apc
 
     def get_reactive_power_converter(self):
         """
         :return: reactive_power_in - reactive_power_out
         """
-        rpc = self.battery.get_value(self.address['reactive_power_in']) - self.battery.get_value(
-            self.address['reactive_power_out'])
+        if not self.battery.get_value(self.address['converter_started']):
+            rpc = 0
+        else:
+            rpc = self.battery.get_value(self.address['reactive_power_in']) - self.battery.get_value(
+                self.address['reactive_power_out'])
         return rpc
 
     def get_soc(self):

--- a/src/battery/math_engine.py
+++ b/src/battery/math_engine.py
@@ -11,24 +11,20 @@ class MathEngine:
         return np.random.normal(mu, sigma)
 
     def get_active_power_in(self, api):
-        
-        if not self.battery.get_value(self.address['input_connected']):
+        if not self.battery.is_input_connected():
             api = 0
         return api
     
     def get_reactive_power_in(self, rpi):
-        
-        if not self.battery.get_value(self.address['input_connected']):
+        if not self.battery.is_input_connected():
             rpi = 0
         return rpi
     
     def get_active_power_out(self, apo):
-        
         return apo
     
     def get_reactive_power_out(self, rpo):
-        
-        if not self.battery.get_value(self.address['input_connected']):
+        if not self.battery.is_input_connected():
             rpo = 0
         return rpo
 
@@ -76,8 +72,6 @@ class MathEngine:
         """
         prev_soc = self.battery.get_value(self.address['soc'])
         apc = self.battery.get_value(self.address['active_power_converter'])
-
-        # multiply by 1000 to convert from kWh
         new_soc = prev_soc + (apc / (self.battery.max_capacity * 3600)) * 100
         if new_soc > 100:
             new_soc = 100
@@ -110,6 +104,8 @@ class MathEngine:
         """
         :return: active_power_in / (sqrt(3) * voltage_l1_l2_in * power_factor_in)
         """
+        if not self.battery.is_input_connected():
+            return 0
         ap = self.battery.get_value(self.address['active_power_in'])
         voltage = self.battery.get_value(self.address['voltage_l1_l2_in'])
         pf = self.get_power_factor_in()
@@ -120,6 +116,8 @@ class MathEngine:
         """
         :return: active_power_in / (sqrt(3) * voltage_l2_l3_in * power_factor_in)
         """
+        if not self.battery.is_input_connected():
+            return 0
         ap = self.battery.get_value(self.address['active_power_in'])
         voltage = self.battery.get_value(self.address['voltage_l2_l3_in'])
         pf = self.get_power_factor_in()
@@ -130,6 +128,8 @@ class MathEngine:
         """
         :return: active_power_in / (sqrt(3) * voltage_l3_l1_in * power_factor_in)
         """
+        if not self.battery.is_input_connected():
+            return 0
         ap = self.battery.get_value(self.address['active_power_in'])
         voltage = self.battery.get_value(self.address['voltage_l3_l1_in'])
         pf = self.get_power_factor_in()

--- a/src/battery/math_engine.py
+++ b/src/battery/math_engine.py
@@ -24,8 +24,8 @@ class MathEngine:
         return apo
     
     def get_reactive_power_out(self, rpo):
-        if not self.battery.is_input_connected():
-            rpo = 0
+        #if not self.battery.is_input_connected():
+            #rpo = 0
         return rpo
 
     def get_power_factor_in(self):
@@ -58,7 +58,7 @@ class MathEngine:
         """
         :return: reactive_power_in - reactive_power_out
         """
-        if not self.battery.get_value(self.address['converter_started']):
+        if not self.battery.is_converter_started():
             rpc = 0
         else:
             rpc = self.battery.get_value(self.address['reactive_power_in']) - self.battery.get_value(

--- a/src/battery/util.py
+++ b/src/battery/util.py
@@ -1,13 +1,11 @@
 from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
 
 
-
 class FloatHandler:
     """
     encodes/decodes float according to the way it is stored in registry
     SCALE stands for multiplying/dividing by scaling factor method, I.E. 32bit int
     COMB stands for storing the float in two registers, I.E. 32bit float
-    :param value: float which should be handled
     """
 
     def __init__(self, env, store):
@@ -17,24 +15,19 @@ class FloatHandler:
         self.battery_store = store
         self.builder = BinaryPayloadBuilder(byteorder=self.byte_order, wordorder=self.word_order)
 
-
     def encode_float(self, value, mode):
+        self.builder.reset()
         if mode == "SCALE":
-            self.builder.reset()
             self.builder.add_32bit_int((round(value * self.scaling_factor)))
         else:
-            self.builder.reset()
             self.builder.add_32bit_float(value)
         return self.builder.to_registers()
 
     def decode_float(self, fx, addr, mode):
+        encoded_value = self.battery_store.getValues(fx, addr, 2)
+        decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
+                                                     wordorder=self.word_order)
         if mode == "SCALE":
-            encoded_value = self.battery_store.getValues(fx, addr, 2)
-            decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
-                                                         wordorder=self.word_order)
+            return decoder.decode_32bit_int() / self.scaling_factor
         else:
-            encoded_value = self.battery_store.getValues(fx, addr, 2)
-            decoder = BinaryPayloadDecoder.fromRegisters(encoded_value, byteorder=self.byte_order,
-                                                         wordorder=self.word_order)
-        return decoder.decode_32bit_int() / self.scaling_factor
-
+            return decoder.decode_32bit_float()

--- a/src/client.py
+++ b/src/client.py
@@ -22,23 +22,24 @@ class GreenerEye:
         addr = field[1]
 
         if fx == 1:
-            val = self.client.read_coils(addr).bits[0]
+            return self.client.read_coils(addr).bits[0]
         elif fx == 2:
-            val = self.client.read_discrete_inputs(addr).bits[0]
+            return self.client.read_discrete_inputs(addr).bits[0]
         elif fx == 3:
-
             mode = field[2]
             val = self.client.read_holding_registers(addr, 2)
         else:
             mode = field[2]
             val = self.client.read_input_registers(addr, 2).registers
+        
         d = self.from_registers(val)
+
+
         if mode == "SCALE":
             return d.decode_32bit_int() / self.scaling_factor
         elif mode == "COMB":
             return d.decode_32bit_float()
-        else:
-            return d
+
 
 
     def from_registers(self, r):
@@ -62,12 +63,20 @@ class GreenerEye:
         r = self.read_value(self.field['frequency_out'])
         print(r)
 
+    def set_converter_started(self, bit):
+        self.client.write_coil(self.field['converter_started'][1], bit)
+    
+    def set_input_connected(self, bit):
+        self.client.write_coil(self.field['input_connected'][1], bit)
+
     def run(self):
         self.client.connect()
         print("CLIENT: is running")
         self.read_float_example()
+        
+        self.set_converter_started(False)
+        self.set_input_connected(False)
 
-        self.client.close()
 
 
 if __name__ == "__main__":

--- a/src/config/env.py
+++ b/src/config/env.py
@@ -15,7 +15,7 @@ env = {
     # simulation will generate I/O power from user defined functions
 
     # realtime delay in sec between iteration, set to 0 for no delay
-    'update_delay': 0.001,
+    'update_delay': 0.5,
 
     # max number of iterations before simulation stops, set to None if infinite iterations
     # overriden by number of rows for historic sim
@@ -26,6 +26,10 @@ env = {
         'system_mode': 5,
         'system_on_backup_battery': 1,
         'accept_values': 1,
+        'converter_started': 0,
+        'input_connected' : 0,
+        
+        # capacity in KwH
         'battery_capacity': 330,
         'id': 'GREENER_001',
     },
@@ -40,7 +44,8 @@ env = {
             "active_power_out",
             "reactive_power_in",
             "reactive_power_out",
-            "frequency_in",
+            "active_power_converter",
+            "reactive_power_converter",
             "soc"
         ]
     },
@@ -126,6 +131,7 @@ env = {
         'accept_values': [coil, 10],
         'converter_started': [coil, 11],
         'input_connected': [coil, 12],
-        'system_on_backup_battery': [coil, 13]}
+        'system_on_backup_battery': [coil, 13]
+        }
 
 }

--- a/src/simulations/random_simulation.py
+++ b/src/simulations/random_simulation.py
@@ -12,7 +12,7 @@ class RandomSimulation(PowerSimulation):
         self.range_active_out = tuple(random_ranges["range_active_power_out"])
         self.range_reactive_out = tuple(random_ranges["range_reactive_power_out"])
         self.start_soc = random_ranges["start_soc"]
-        battery.set_value(battery.address["soc"], self.start_soc)
+        battery.set_value(battery.field["soc"], self.start_soc)
         self.update()
 
     def rand(self, range):

--- a/src/simulations/simulation_model.py
+++ b/src/simulations/simulation_model.py
@@ -13,7 +13,7 @@ class Simulation(PowerSimulation):
         self.apo_fun = env["active_power_out"]
         self.rpo_fun = env["reactive_power_out"]
         self.start_soc = env["start_soc"]
-        battery.set_value(battery.address["soc"], self.start_soc)
+        battery.set_value(battery.field["soc"], self.start_soc)
         self.update()
 
     def update(self):


### PR DESCRIPTION
```converter_started = 0``` sets ```active/reactive_power_converter``` to zero
```input_connected = 0```  sets ```active/reactive_power in``` to zero
i dont know if you guys know any fields from the given battery constants affect other things than these above. Jasper didn't provide exactly a clear explanation what everyone of them did. But this is what i came up with