### PR TITLE
created setup file with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="power_simulation",
+    version='0.1',
+    packages=find_packages(),
+    author='Mariya Shumska, Chris Worthington, Victor Florea, Sjoerd Hilhorst',
+    install_requires=[
+        'pandas',
+        'pymodbus',
+        'twisted',
+        'numpy',
+    ]
+)


### PR DESCRIPTION
i was wrong about downloading the dependencies from the requirements txt, i am still not exactly clear what exactly the difference is between, why it needs to be different, [this](https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py) explains it a little. This file create a setup file with setuptools, and works, as far as far as i understand it. you can run it with ```pip3 install - e .```